### PR TITLE
move @babel/runtime and @types to devDependencies since we don't want…

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "react": ">=16.12"
   },
   "dependencies": {
-    "@babel/runtime": "^7.9.2",
-    "@types/use-deep-compare-effect": "^1.2.0",
     "dequal": "^1.0.0"
   },
   "devDependencies": {
+    "@babel/runtime": "^7.9.2",
     "@testing-library/react-hooks": "^3.2.1",
+    "@types/use-deep-compare-effect": "^1.2.0",
     "jest-in-case": "^1.0.2",
     "kcd-scripts": "^5.6.0",
     "react": "^16.13.1",


### PR DESCRIPTION
Resolves https://github.com/kentcdodds/use-deep-compare-effect/issues/18

This moves both `@babel/runtime` to dependencies since this can lead to dupes, .... also not a real dependency to this lib.
Moves `@types/<this-lib>` to devDeps because not everyone uses TS and most editors give hints to install this