### PR TITLE
fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,4 +174,6 @@ MIT
 [bugs]: https://github.com/kentcdodds/use-deep-compare-effect/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Acreated-desc+label%3Abug
 [requests]: https://github.com/kentcdodds/use-deep-compare-effect/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+label%3Aenhancement
 [good-first-issue]: https://github.com/kentcdodds/use-deep-compare-effect/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+label%3Aenhancement+label%3A%22good+first+issue%22
+[react-hooks]: https://reactjs.org/docs/hooks-effect.html
+[object-is]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
**What**:

Several links are broken in the `README.md` file. This impacts both the GitHub repository and the npm page.

**Why**:

Because broken links look sloppy and are distracting.

**How**:

Add missing links, which I found in the git history. You can check my fork to ensure the links are working.

**Checklist**:

- [ ] Documentation N/A
- [ x ] Tests
- [ x ] Ready to be merged

**More Details**:

- These links were originally added in [this commit](https://github.com/kentcdodds/use-deep-compare-effect/commit/cb792ffff6db98fea912e0e83d57b5bed1787945).
- These links were removed in [this commit](https://github.com/kentcdodds/use-deep-compare-effect/commit/71d6f7e9a932aabe1f82f0c51a406376b01b869f#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5). This seems like a simple mistake to me (not an intentional change).