### PR TITLE
Pr/export use deep compare memoize

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ function isPrimitive(val: unknown) {
   return val == null || /^[sbn]/.test(typeof val)
 }
 
-function useDeepCompareMemoize(value: DependencyList) {
+export function useDeepCompareMemoize(value: DependencyList) {
   const ref = React.useRef<DependencyList>()
   const signalRef = React.useRef<number>(0)
 


### PR DESCRIPTION
**What**:
Export useDeepCompareMemoize in src/index

**Why**:
This function can be useful in other circumstances. I have this need, and since it is not exported, for now I must duplicate the code.

**Checklist**:
- [ ] Documentation N/A
- [ ] Tests N/A
- [X] Ready to be merged

** Note **
I wondered if some docs are needed about this newly exported function. Since the existent secondary export, useDeepCompareEffectNoCheck, does not have documentation, I assumed it is not needed.
