### PR TITLE
improve useDeepCompareMemoize

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,12 @@ function isPrimitive(val: unknown) {
   return val == null || /^[sbn]/.test(typeof val)
 }
 
-export function useDeepCompareMemoize(value: DependencyList) {
-  const ref = React.useRef<DependencyList>()
+/**
+ * @param value the value to be memoized (usually a dependency list)
+ * @returns a momoized version of the value as long as it remains deeply equal
+ */
+export function useDeepCompareMemoize<T>(value: T) {
+  const ref = React.useRef<T>(value)
   const signalRef = React.useRef<number>(0)
 
   if (!deepEqual(value, ref.current)) {
@@ -34,7 +38,8 @@ export function useDeepCompareMemoize(value: DependencyList) {
     signalRef.current += 1
   }
 
-  return [signalRef.current]
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return React.useMemo(() => ref.current, [signalRef.current])
 }
 
 function useDeepCompareEffect(


### PR DESCRIPTION
**What**:

Improve useDeepCompareMemoize:
1. return the memoized value instead of the memoized version signal
2. use a generic type

**Why**:

1. Getting the memoized version of the value does the same job, but it is more powerfull: one can get this memoized value, then use it in any hook (useEffect, but also useMemo, useCallback, and any custom hook using a depencies list).
2. This generic type is more accurate to describe what this hook can do: it does not damage the types in useDeepCompareEffect, but allows using useDeepCompareMemoize with any other value type. It could be used with an object that will then be used in a hook, along with other variables.

**How**:

1. Using useMemo inside useDeepCompareMemoize.
2. Using a generic type <T>.

**Checklist**:

- [X] Documentation
- [X] Tests
- [X] Ready to be merged
