### PR TITLE
fix(deps): move @types/react to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@types/react": "^17.0.0",
     "dequal": "^2.0.2"
   },
   "devDependencies": {
     "@testing-library/react-hooks": "^3.4.2",
+    "@types/react": "^17.0.0",
     "jest-in-case": "^1.0.2",
     "kcd-scripts": "^7.2.1",
     "react": "^17.0.1",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: This PR moves `@types/react` to peerDependencies.

<!-- Why are these changes necessary? -->

**Why**: Since `react` is a peer dependency,  we shouldn't be adding `@types/react` as a dependency locked at `^17.0.0`. This can cause issues with libraries using `use-deep-compare-effect` that are on react 16.


<!-- How were these changes implemented? -->

**How**: By moving `@types/react` to peerDependencies.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation (N/A)
- [ ] Tests (N/A)
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
